### PR TITLE
Remove '.nojekyll' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 # Visual Studio cache/options directory
 .vs/
-
-.nojekyll


### PR DESCRIPTION
Remove '.nojekyll' from .gitignore as pages links stopped working